### PR TITLE
[顧客topのviewを少し変更]

### DIFF
--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -15,6 +15,7 @@
         <div class="row">
         <% @items.last(4).each do |item| %>
           <div class="col-lg-3" style="padding-right: 0px; padding-left: 0px;">
+            <% if item.is_status==false %>
             <% if item.image.attached? %>
               <%= link_to item_path(item.id) do %>
               <%= image_tag item.image, size: "150x150" %><br>
@@ -26,8 +27,9 @@
 						<% end %>
             <%= item.name %><br>
             ¥<%= item.price.to_s(:delimited, delimiter: ',') %>
-          </div>
             <% end %>
+          </div>
+          <% end %>
         </div>
 
             <h3>


### PR DESCRIPTION
管理者が販売中止中で商品を新規登録した際でも
顧客のTOPページに販売中止中の画像が表示されていたので
販売中のみの画像に変更しました。
